### PR TITLE
adding scheme integrations for attribute data

### DIFF
--- a/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/DarkLoop.Azure.Functions.Authorize.SampleFunctions.csproj
+++ b/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/DarkLoop.Azure.Functions.Authorize.SampleFunctions.csproj
@@ -5,6 +5,8 @@
     <UserSecretsId>51dc0b9d-8e74-45ec-aebc-1d3d6934faf5</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization.Policy" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
   </ItemGroup>

--- a/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Startup.cs
+++ b/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Startup.cs
@@ -46,6 +46,7 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions
                             //var response = x.Response;
                             //response.ContentType = "text/plain";
                             //response.ContentLength = 5;
+                            //response.StatusCode = 401;
                             //await response.WriteAsync("No go");
                             //await response.Body.FlushAsync();
                         }

--- a/src/DarkLoop.Azure.Functions.Authorize/Bindings/FunctionsAuthorizeBindingProvider.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Bindings/FunctionsAuthorizeBindingProvider.cs
@@ -21,7 +21,7 @@ namespace DarkLoop.Azure.Functions.Authorize.Bindings
             _filtersIndex = filterIndex;
         }
 
-        public async Task<IBinding> TryCreateAsync(BindingProviderContext context)
+        public async Task<IBinding?> TryCreateAsync(BindingProviderContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -29,7 +29,6 @@ namespace DarkLoop.Azure.Functions.Authorize.Bindings
             if (paramType == typeof(HttpRequest) || paramType == typeof(HttpRequestMessage))
             {
                 await this.ProcessAuthorizationAsync(context.Parameter);
-                Console.WriteLine($"Processed auth info for {context.Parameter.Member.Name}.");
             }
 
             return null;
@@ -38,6 +37,9 @@ namespace DarkLoop.Azure.Functions.Authorize.Bindings
         private Task ProcessAuthorizationAsync(ParameterInfo info)
         {
             var method = info.Member as MethodInfo;
+
+            if (method == null) throw new InvalidOperationException($"Unable to bind authorization context for {info.Name}.");
+
             var cls = method.DeclaringType;
 
             var allowAnonymous = method.GetCustomAttribute<AllowAnonymousAttribute>();

--- a/src/DarkLoop.Azure.Functions.Authorize/Constants.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Constants.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DarkLoop.Azure.Functions.Authorize
+{
+    internal class Constants
+    {
+        internal const string AuthInvokedKey = "__WebJobAuthInvoked";
+        internal const string WebJobsAuthScheme = "WebJobsAuthLevel";
+    }
+}

--- a/src/DarkLoop.Azure.Functions.Authorize/DarkLoop.Azure.Functions.Authorize.csproj
+++ b/src/DarkLoop.Azure.Functions.Authorize/DarkLoop.Azure.Functions.Authorize.csproj
@@ -7,6 +7,8 @@
         <Product>Azure Functions Authorize</Product>
         <Description>Allows same AuthorizeAttribute behavior for Azure Functions V3+</Description>
         <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+        <Nullable>enable</Nullable>
+        <UserSecretsId>3472ff41-3859-4101-a2da-6c37d751fd31</UserSecretsId>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -21,10 +23,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.0.3" />
         <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.10.0" />
         <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12">
             <IncludeAssets>
                 <IsPackable>true</IsPackable>

--- a/src/DarkLoop.Azure.Functions.Authorize/FunctionAuthorizeAttribute.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/FunctionAuthorizeAttribute.cs
@@ -22,11 +22,11 @@ namespace DarkLoop.Azure.Functions.Authorize
             this.Policy = policy;
         }
 
-        public string Policy { get; set; }
+        public string? Policy { get; set; }
 
-        public string Roles { get; set; }
+        public string? Roles { get; set; }
 
-        public string AuthenticationSchemes { get; set; }
+        public string? AuthenticationSchemes { get; set; }
 
         async Task IFunctionInvocationFilter.OnExecutingAsync(FunctionExecutingContext executingContext, CancellationToken cancellationToken)
         {
@@ -53,7 +53,7 @@ namespace DarkLoop.Azure.Functions.Authorize
             return (bool)value;
         }
 
-        private HttpContext GetHttpContext(FunctionExecutingContext context)
+        private HttpContext? GetHttpContext(FunctionExecutingContext context)
         {
             var requestOrMessage = context.Arguments.Values.FirstOrDefault(x => x is HttpRequest || x is HttpRequestMessage);
 

--- a/src/DarkLoop.Azure.Functions.Authorize/Handlers/AuthenticationRequestHandler.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Handlers/AuthenticationRequestHandler.cs
@@ -12,7 +12,7 @@ namespace DarkLoop.Azure.Functions.Authorize.Handlers
 {
     public static class AuthenticationRequestHandler
     {
-        public static async Task<IActionResult> HandleAuthenticateAsync(HttpContext context, string scheme)
+        public static async Task<IActionResult?> HandleAuthenticateAsync(HttpContext context, string scheme)
         {
             var handler = await GetSchemeHandler(context, scheme);
             if(await handler.HandleRequestAsync())

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/AuthenticationExtensions.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/AuthenticationExtensions.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+using DarkLoop.Azure.Functions.Authorize;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
@@ -26,14 +27,14 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         public static AuthenticationBuilder AddAuthentication(
-            this IFunctionsHostBuilder builder, Action<AuthenticationOptions> configure)
+            this IFunctionsHostBuilder builder, Action<AuthenticationOptions>? configure)
         {
             if (builder == null)
             {
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            if(configure!=null)
+            if (configure != null)
             {
                 builder.Services.AddSingleton<IConfigureOptions<AuthenticationOptions>>(provider =>
                     new ConfigureOptions<AuthenticationOptions>(options =>
@@ -49,7 +50,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static AuthenticationBuilder AddScriptFunctionsJwtBearer(this AuthenticationBuilder builder)
         {
-            return builder.AddJwtBearer("WebJobsAuthLevel", options =>
+            return builder.AddJwtBearer(Constants.WebJobsAuthScheme, options =>
             {
                 options.Events = new JwtBearerEvents
                 {

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/FunctionAuthorizationContext.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/FunctionAuthorizationContext.cs
@@ -15,6 +15,6 @@ namespace DarkLoop.Azure.Functions.Authorize.Security
 
         public HttpContext HttpContext { get; }
 
-        public IActionResult Result { get; internal set; }
+        public IActionResult? Result { get; internal set; }
     }
 }


### PR DESCRIPTION
When building policy for the specified attributes on function, schemes where not considered and authentication processing was not affecting request's `HttpContext`.
Addresses #3 