### PR TITLE
Adding built-in auth to extension methods

### DIFF
--- a/.build/release.props
+++ b/.build/release.props
@@ -2,19 +2,21 @@
 
     <PropertyGroup>
         <Authors>Arturo Martinez</Authors>
+		<Company>DarkLoop</Company>
         <PackageId>DarkLoop.Azure.Functions.Authorize</PackageId>
         <IsPreview>true</IsPreview>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
-        <Version>3.0.12</Version>
+        <Version>3.1.0</Version>
         <FileVersion>$(Version).0</FileVersion>
         <RepositoryUrl>https://github.com/dark-loop/functions-authorize</RepositoryUrl>
         <License>https://github.com/dark-loop/functions-authorize/blob/master/LICENSE</License>
         <RepositoryType>Git</RepositoryType>
-        <PackageTags>AuthorizeAttribute, Authorize, Azure Functions</PackageTags>
+        <PackageTags>AuthorizeAttribute, Authorize, Azure Functions, Azure, Bearer, JWT</PackageTags>
         <PackageIconUrl>https://en.gravatar.com/userimage/22176525/45f25acea686a783e5b2ca172d72db71.png</PackageIconUrl>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dl-sftwr-sn-key.snk</AssemblyOriginatorKeyFile>
         <IsPackable>true</IsPackable>
+		<Description>Azure Functions V3 authentication extensions to enable authentication and authorization on a per function basis.</Description>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/DarkLoop.Azure.Functions.Authorize.SampleFunctions.csproj
+++ b/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/DarkLoop.Azure.Functions.Authorize.SampleFunctions.csproj
@@ -5,7 +5,7 @@
     <UserSecretsId>51dc0b9d-8e74-45ec-aebc-1d3d6934faf5</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization.Policy" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />

--- a/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Function1.cs
+++ b/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Function1.cs
@@ -1,9 +1,13 @@
 using System.IO;
+using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -17,19 +21,17 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequest req,
             ILogger log)
         {
-            log.LogInformation("C# HTTP trigger function processed a request.");
+            var provider = req.HttpContext.RequestServices;
+            var schProvider = provider.GetService<IAuthenticationSchemeProvider>();
 
-            string name = req.Query["name"];
+            var sb = new StringBuilder();
+            foreach (var scheme in await schProvider.GetAllSchemesAsync())
+                sb.AppendLine($"{scheme.Name} -> {scheme.HandlerType}");
 
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            dynamic data = JsonConvert.DeserializeObject(requestBody);
-            name = name ?? data?.name;
+            sb.AppendLine();
+            sb.AppendLine(Assembly.GetEntryAssembly().FullName);
 
-            string responseMessage = string.IsNullOrEmpty(name)
-                ? "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response."
-                : $"Hello, {name}. This HTTP triggered function executed successfully.";
-
-            return new OkObjectResult(responseMessage);
+            return new OkObjectResult(sb.ToString());
         }
     }
 }

--- a/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Startup.cs
+++ b/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Startup.cs
@@ -45,12 +45,12 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions
                         OnChallenge = async x =>
                         {
                             // un-commenting the following lines would override what the internals do to send an unauthorized response
-                            var response = x.Response;
-                            response.ContentType = "text/plain";
-                            response.ContentLength = 5;
-                            response.StatusCode = 401;
-                            await response.WriteAsync("No go");
-                            await response.Body.FlushAsync();
+                            //var response = x.Response;
+                            //response.ContentType = "text/plain";
+                            //response.ContentLength = 5;
+                            //response.StatusCode = 401;
+                            //await response.WriteAsync("No go");
+                            //await response.Body.FlushAsync();
                         }
                     };
                 }, true);

--- a/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Startup.cs
+++ b/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Startup.cs
@@ -19,7 +19,7 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions
         public override void Configure(IFunctionsHostBuilder builder)
         {
             builder
-                .AddAuthentication(options=>
+                .AddAuthentication(options =>
                 {
                     options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
                     options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
@@ -37,7 +37,8 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions
                             var response = x.Response;
                             response.ContentType = "text/plain";
                             response.ContentLength = 5;
-                            await response.WriteAsync("No go");
+                            response.StatusCode = 401;
+                            await response.WriteAsync("Unauthorized request");
                             await response.Body.FlushAsync();
                         },
                         OnChallenge = async x =>
@@ -51,7 +52,7 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions
                             //await response.Body.FlushAsync();
                         }
                     };
-                });
+                }, true);
 
             builder.AddAuthorization();
         }

--- a/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Startup.cs
+++ b/sample/DarkLoop.Azure.Functions.Authorize.SampleFunctions/Startup.cs
@@ -18,8 +18,8 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions
 
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            builder
-                .AddAuthentication(options =>
+            builder.Services
+                .AddFunctionsAuthentication(options =>
                 {
                     options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
                     options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
@@ -34,27 +34,28 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions
                     {
                         OnAuthenticationFailed = async x =>
                         {
+                            var body = "Unauthorized request";
                             var response = x.Response;
                             response.ContentType = "text/plain";
-                            response.ContentLength = 5;
+                            response.ContentLength = body.Length;
                             response.StatusCode = 401;
-                            await response.WriteAsync("Unauthorized request");
+                            await response.WriteAsync(body);
                             await response.Body.FlushAsync();
                         },
                         OnChallenge = async x =>
                         {
                             // un-commenting the following lines would override what the internals do to send an unauthorized response
-                            //var response = x.Response;
-                            //response.ContentType = "text/plain";
-                            //response.ContentLength = 5;
-                            //response.StatusCode = 401;
-                            //await response.WriteAsync("No go");
-                            //await response.Body.FlushAsync();
+                            var response = x.Response;
+                            response.ContentType = "text/plain";
+                            response.ContentLength = 5;
+                            response.StatusCode = 401;
+                            await response.WriteAsync("No go");
+                            await response.Body.FlushAsync();
                         }
                     };
                 }, true);
 
-            builder.AddAuthorization();
+            builder.Services.AddFunctionsAuthorization();
         }
 
         public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)

--- a/src/DarkLoop.Azure.Functions.Authorize/Constants.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Constants.cs
@@ -8,5 +8,6 @@ namespace DarkLoop.Azure.Functions.Authorize
     {
         internal const string AuthInvokedKey = "__WebJobAuthInvoked";
         internal const string WebJobsAuthScheme = "WebJobsAuthLevel";
+        internal const string ArmTokenAuthScheme = "ArmToken";
     }
 }

--- a/src/DarkLoop.Azure.Functions.Authorize/Filters/FunctionsAuthorizeFilter.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Filters/FunctionsAuthorizeFilter.cs
@@ -13,6 +13,11 @@ namespace DarkLoop.Azure.Functions.Authorize.Filters
 {
     internal class FunctionsAuthorizeFilter : IFunctionsAuthorizeFilter
     {
+        private static readonly IEnumerable<string> __dismissedSchemes = 
+            AuthHelper.EnableAuth ? 
+                new[] { Constants.WebJobsAuthScheme } :
+                new[] { Constants.WebJobsAuthScheme, Constants.ArmTokenAuthScheme };  
+
         public IEnumerable<IAuthorizeData> AuthorizeData { get; }
 
         public IAuthenticationSchemeProvider SchemeProvider { get; }
@@ -39,7 +44,7 @@ namespace DarkLoop.Azure.Functions.Authorize.Filters
             var schemes = this.SchemeProvider.GetAllSchemesAsync().GetAwaiter().GetResult();
             var strSchemes = string.Join(',',
                 from scheme in schemes
-                where scheme.Name != Constants.WebJobsAuthScheme
+                where !__dismissedSchemes.Contains(scheme.Name)
                 select scheme.Name);
 
             foreach (var data in this.AuthorizeData)

--- a/src/DarkLoop.Azure.Functions.Authorize/FunctionAuthorizeAttribute.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/FunctionAuthorizeAttribute.cs
@@ -11,6 +11,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace DarkLoop.Azure.Functions.Authorize
 {
+    /// <summary>
+    /// Represents authorization logic that needs to be applied to a function.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     [Obsolete("This class is dependent on Azure Functions preview features.")]
     public class FunctionAuthorizeAttribute : FunctionInvocationFilterAttribute, IFunctionInvocationFilter, IAuthorizeData
@@ -22,10 +25,19 @@ namespace DarkLoop.Azure.Functions.Authorize
             this.Policy = policy;
         }
 
+        /// <summary>
+        /// Gets or sets the name of the authorization policy to apply to function.
+        /// </summary>
         public string? Policy { get; set; }
 
+        /// <summary>
+        /// Gets or sets a comma separated list of roles that are required to execute function.
+        /// </summary>
         public string? Roles { get; set; }
 
+        /// <summary>
+        /// Gets or sets a comma separated list of authentication schemes that are required to apply the authorization logic.
+        /// </summary>
         public string? AuthenticationSchemes { get; set; }
 
         async Task IFunctionInvocationFilter.OnExecutingAsync(FunctionExecutingContext executingContext, CancellationToken cancellationToken)

--- a/src/DarkLoop.Azure.Functions.Authorize/FunctionsAuthExtension.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/FunctionsAuthExtension.cs
@@ -8,7 +8,7 @@ namespace DarkLoop.Azure.Functions.Authorize
     {
         public void Initialize(ExtensionConfigContext context)
         {
-
+            
         }
     }
 }

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/AuthHelper.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/AuthHelper.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace DarkLoop.Azure.Functions.Authorize.Security
+{
+    internal class AuthHelper
+    {
+        protected static Assembly ScriptWebHostAssembly = Assembly.Load("Microsoft.Azure.WebJobs.Script.WebHost");
+        private static Type JwtSecurityExtsType = 
+            ScriptWebHostAssembly.GetType("Microsoft.Extensions.DependencyInjection.ScriptJwtBearerExtensions");
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> __func = BuildFunc();
+
+        internal static bool EnableAuth { get; private set; }
+
+        static AuthHelper()
+        {
+            var entry = Assembly.GetEntryAssembly();
+            var fullName = entry.FullName;
+            var name = fullName.Substring(0, fullName.IndexOf(','));
+            EnableAuth = name.Equals("Microsoft.Azure.WebJobs.Script.WebHost", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> BuildFunc()
+        {
+            var builder = Expression.Parameter(typeof(AuthenticationBuilder), "builder");
+            var method = Expression.Call(JwtSecurityExtsType, "AddScriptJwtBearer", Type.EmptyTypes, builder);
+            var lambda = Expression.Lambda<Func<AuthenticationBuilder, AuthenticationBuilder>>(method, builder);
+
+            return lambda.Compile();
+        }
+
+        internal static FunctionsAuthenticationBuilder AddScriptJwtBearer(FunctionsAuthenticationBuilder builder)
+        {
+            __func(builder);
+            return builder;
+        }
+    }
+}

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/AuthorizationExtensions.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/AuthorizationExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using DarkLoop.Azure.Functions.Authorize.Bindings;
 using DarkLoop.Azure.Functions.Authorize.Filters;
+using DarkLoop.Azure.Functions.Authorize.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Azure.WebJobs;
@@ -13,31 +14,59 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class AuthorizationExtensions
     {
+        /// <summary>
+        /// Adds Functions built-in authorization.
+        /// </summary>
+        /// <param name="builder">The <see cref="IFunctionsHostBuilder"/> containing the services collection to configure.</param>
         public static IFunctionsHostBuilder AddAuthorization(this IFunctionsHostBuilder builder)
         {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
+            if (builder == null) throw new ArgumentNullException(nameof(builder));
 
-            builder.Services.AddAuthorizationCore();
+            builder.Services.AddFunctionsAuthorization(delegate { });
+            
             return builder;
         }
 
+        /// <summary>
+        /// Adds Functions built-in auhotrization.
+        /// </summary>
+        /// <param name="services">The service collection to configure.</param>
+        public static IServiceCollection AddFunctionsAuthorization(this IServiceCollection services)
+        {
+            if (services is null) throw new ArgumentNullException(nameof(services));
+
+            return services.AddFunctionsAuthorization(delegate { });
+        }
+
+        /// <summary>
+        /// Adds Functions built-in authorization handlers and allows for further configuration.
+        /// </summary>
+        /// <param name="builder">The <see cref="IFunctionsHostBuilder"/> containing the services collection to configure.</param>
+        /// <param name="configure">The method to configure the authorization options.</param>
         public static IFunctionsHostBuilder AddAuthorization(this IFunctionsHostBuilder builder, Action<AuthorizationOptions> configure)
         {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
+            if (builder is null) throw new ArgumentNullException(nameof(builder));
 
-            if (configure == null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
+            builder.Services.AddFunctionsAuthorization(configure);
 
-            builder.Services.Configure(configure);
-            return builder.AddAuthorization();
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds Function built-in authorization handlers and allows for further configuration.
+        /// </summary>
+        /// <param name="services">The service collection to configure.</param>
+        /// <param name="configure">The method to configure the authorization options.</param>
+        public static IServiceCollection AddFunctionsAuthorization(
+            this IServiceCollection services, Action<AuthorizationOptions> configure)
+        {
+            if (services is null) throw new ArgumentNullException(nameof(services));
+            if (configure is null) throw new ArgumentNullException(nameof(configure));
+
+            AuthHelper.AddFunctionsBuiltInAuthorization(services);
+            services.Configure(configure);
+
+            return services;
         }
     }
 }

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/DisabledAuthHelper.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/DisabledAuthHelper.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace DarkLoop.Azure.Functions.Authorize.Security
+{
+    internal class DisabledAuthHelper : AuthHelper
+    {
+        private static Assembly FuncAssembly = Assembly.Load("func");
+        private static MethodInfo AddSchemeMethod =
+            typeof(AuthenticationBuilder).GetMethods().SingleOrDefault(x =>
+                x.Name == "AddScheme" &&
+                x.IsGenericMethod &&
+                x.GetParameters().Length == 2);
+        private static Type AuthLOptions = 
+            ScriptWebHostAssembly.GetType("Microsoft.Azure.WebJobs.Script.WebHost.Authentication.AuthenticationLevelOptions");
+        private static Type ArmTOptions =
+            ScriptWebHostAssembly.GetType("Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication.ArmAuthenticationOptions");
+        private static Type CliAuthHandler =
+            FuncAssembly.GetType("Azure.Functions.Cli.Actions.HostActions.WebHost.Security.CliAuthenticationHandler`1");
+
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> __authLDisabled = BuildAuthLFunc();
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> __armTokenDisabled = BuildArmTFunc();
+
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> BuildAuthLFunc()
+        {
+            var builder = Expression.Parameter(typeof(AuthenticationBuilder), "builder");
+            var scheme = Expression.Constant(Constants.WebJobsAuthScheme);
+            var action = Expression.Lambda(Expression.Empty(), Expression.Parameter(AuthLOptions, "options"));
+            var genMethod = AddSchemeMethod.MakeGenericMethod(AuthLOptions, CliAuthHandler.MakeGenericType(AuthLOptions));
+            var method = Expression.Call(builder, genMethod, scheme, action);
+            var lambda = Expression.Lambda<Func<AuthenticationBuilder, AuthenticationBuilder>>(method, builder);
+            return lambda.Compile();
+        }
+
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> BuildArmTFunc()
+        {
+            var builder = Expression.Parameter(typeof(AuthenticationBuilder), "builder");
+            var scheme = Expression.Constant(Constants.ArmTokenAuthScheme);
+            var action = Expression.Lambda(Expression.Empty(), Expression.Parameter(ArmTOptions, "options"));
+            var genMethod = AddSchemeMethod.MakeGenericMethod(ArmTOptions, CliAuthHandler.MakeGenericType(ArmTOptions));
+            var method = Expression.Call(builder, genMethod, scheme, action);
+            var lambda = Expression.Lambda<Func<AuthenticationBuilder, AuthenticationBuilder>>(method, builder);
+            return lambda.Compile();
+        }
+
+        internal static FunctionsAuthenticationBuilder AddScriptAuthLevel(FunctionsAuthenticationBuilder builder)
+        {
+            __authLDisabled(builder);
+            return builder;
+        }
+
+        internal static FunctionsAuthenticationBuilder AddArmToken(FunctionsAuthenticationBuilder builder)
+        {
+            __armTokenDisabled(builder);
+            return builder;
+        }
+    }
+}

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/EnabledAuthHelper.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/EnabledAuthHelper.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace DarkLoop.Azure.Functions.Authorize.Security
+{
+    internal class EnabledAuthHelper : AuthHelper
+    {
+        private static Type ArmExtensionsType =
+            ScriptWebHostAssembly.GetType("Microsoft.Extensions.DependencyInjection.ArmAuthenticationExtensions");
+        private static Type AuthLExtensionsType =
+            ScriptWebHostAssembly.GetType("Microsoft.Extensions.DependencyInjection.AuthLevelExtensions");
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> __armFunc = BuildArmFunc();
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> __authLFunc = BuildAuthLFunc();
+
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> BuildArmFunc()
+        {
+            var builder = Expression.Parameter(typeof(AuthenticationBuilder), "builder");
+            var method = Expression.Call(ArmExtensionsType, "AddArmToken", Type.EmptyTypes, builder);
+            var lambda = Expression.Lambda<Func<AuthenticationBuilder, AuthenticationBuilder>>(method, builder);
+            return lambda.Compile();
+        }
+
+        private static Func<AuthenticationBuilder, AuthenticationBuilder> BuildAuthLFunc()
+        {
+            var builder = Expression.Parameter(typeof(AuthenticationBuilder), "builder");
+            var method = Expression.Call(AuthLExtensionsType, "AddScriptAuthLevel", Type.EmptyTypes, builder);
+            var lambda = Expression.Lambda<Func<AuthenticationBuilder, AuthenticationBuilder>>(method, builder);
+            return lambda.Compile();
+        }
+
+        internal static FunctionsAuthenticationBuilder AddArmToken(FunctionsAuthenticationBuilder builder)
+        {
+            __armFunc(builder);
+            return builder;
+        }
+
+        internal static FunctionsAuthenticationBuilder AddScriptAuthLevel(FunctionsAuthenticationBuilder builder)
+        {
+            __authLFunc(builder);
+            return builder;
+        }
+    }
+}

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/FunctionsAuthenticationBuilder.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/FunctionsAuthenticationBuilder.cs
@@ -13,8 +13,8 @@ namespace DarkLoop.Azure.Functions.Authorize.Security
     /// </summary>
     public class FunctionsAuthenticationBuilder : AuthenticationBuilder
     {
-        internal FunctionsAuthenticationBuilder(IFunctionsHostBuilder builder)
-            : base(builder.Services) { }
+        internal FunctionsAuthenticationBuilder(IServiceCollection services)
+            : base(services) { }
 
         /// <summary>
         /// Adds the JWT Bearer scheme to the authentication configuration. JWT is added by default to Azure Functions 

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/FunctionsAuthenticationBuilder.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/FunctionsAuthenticationBuilder.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+using System.Linq;
+
+namespace DarkLoop.Azure.Functions.Authorize.Security
+{
+    /// <summary>
+    /// An <see cref="AuthenticationBuilder"/> that enhances the built-in authentication behavior for Azure Functions.
+    /// </summary>
+    public class FunctionsAuthenticationBuilder : AuthenticationBuilder
+    {
+        internal FunctionsAuthenticationBuilder(IFunctionsHostBuilder builder)
+            : base(builder.Services) { }
+
+        /// <summary>
+        /// Adds the JWT Bearer scheme to the authentication configuration. JWT is added by default to Azure Functions 
+        /// and all HTTP functions are applied the Admin level after a token is validated.
+        /// </summary>
+        /// <param name="removeBuiltInConfig">A value indicating whether remove the built-in configuration for JWT.
+        /// Bearer scheme is still in place, but Admin level is not set incoming requests.</param>
+        /// <returns>A instance of the <see cref="FunctionsAuthenticationBuilder"/></returns>
+        public FunctionsAuthenticationBuilder AddJwtBearer(bool removeBuiltInConfig = false)
+        {
+            return this.AddJwtBearer(delegate { }, removeBuiltInConfig);
+        }
+
+        /// <summary>
+        /// Adds the JWT Bearer scheme to the authentication configuration. JWT is added by default to Azure Functions 
+        /// and all HTTP functions are applied the Admin level after a token is validated.
+        /// </summary>
+        /// <param name="configureOptions">An action configuring the JWT options for authentication. 
+        /// <para>When <see cref="removeBuiltInConfig"/> is set to false, it enhances the built-in configuration for the scheme</para></param>
+        /// <param name="removeBuiltInConfig">A value indicating whether remove the built-in configuration for JWT.
+        /// Bearer scheme is still in place, but Admin level is not set incoming requests.</param>
+        /// <returns>A instance of the <see cref="FunctionsAuthenticationBuilder"/></returns>
+        public FunctionsAuthenticationBuilder AddJwtBearer(Action<JwtBearerOptions> configureOptions, bool removeBuiltInConfig = false)
+        {
+            if(removeBuiltInConfig)
+            {
+                var descriptor = Services.FirstOrDefault(s => s.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>));
+                Services.Remove(descriptor);
+            }
+
+            this.Services
+                .AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+                .Configure(configureOptions);
+
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
Adding built-in authentication to extension methods for `IFunctionsHostBuilder` and `IServiceCollection`. Having this setup will not affect Azure portal ability to inspect and test functions. This addresses issue #5.
Azure portal shouldn't show message 'Azure Function Runtime is unreachable' anymore 