### PR TITLE
Removing existing Bearer configuration by default when adding custom bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,6 @@ public class Functions
 Adding change log starting with version 3.1.3
 
 ### 3.1.3
+- #### Remove Functions bult-in JwtBearer configuration by default (Breaking change?)
+  Azure Functions recently [added configuration](https://github.com/Azure/azure-functions-host/pull/9678) for issuer and audience validation for the default authentication flows, not the one supported by this package through `FunctionAuthorizeAttribute`, which interferes with token validation when using our own Bearer scheme token configuration.
+  In prior versions, this package has functionality to clear Functions built-in configuration, but it was not enabled by default when using `AddJwtBearer(Action<JwtBearerOptions> configure, bool removeBuiltInConfig = false)`. Since the use of this package is commonly used for custom JWT token, the default value of `removeBuiltInConfig` is now `true`.


### PR DESCRIPTION
When using this package `AddAuthentication` or `AddFunctionsAuthentication` extension methods, it was leaving built-in functions host configuration in place. `AddJwtBearer` contains a `removeBuiltInConfig` optional parameter having a default value of `false`.
This change switches the default value to `true`, which removes all configuration the host has introduced for the `Bearer` scheme. Only custom configuration is left in place.

This change addresses issue #19 and #21