### PR TITLE
adding helper method to detect local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Adding change log starting with version 3.1.3
 
   Optionally you can bind it to configuration to rely on providers like User Secrets or Azure App Configuration to disable and re-enable without having to restart your application:
   ```c#
-  builder.Services.Configure<FunctionsAuthorizationOptions>(Configuration.GetSection("FunctionsAuthorization"));
+  builder.Services.Configure<FunctionsAuthorizationOptions>(
+      Configuration.GetSection("FunctionsAuthorization"));
   ```
 
   For function apps targeting .NET 7 or greater, you can also use `AuthorizationBuilder` to set this value:
@@ -116,7 +117,14 @@ Adding change log starting with version 3.1.3
       .DisableAuthorization(Configuration.GetValue<bool>("AuthOptions:DisableAuthorization"));
   ```
 
-  Its always recommended to encapsulate this logic within checks for environments to ensure that if the configuration setting is unintentionally moved to a non-desired environment, it would not affect security of our HTTP triggered functions.
+  Its always recommended to encapsulate this logic within checks for environments to ensure that if the configuration setting is unintentionally moved to a non-desired environment, it would not affect security of our HTTP triggered functions. This change adds a helper method to identify if you are running the function app in the local environment:
+  ```c#
+  if (builder.IsLocalAuthorizationContext())
+  {
+      builder.Services.Configure<FunctionsAuthorizationOptions>(
+          options => options.AuthorizationDisabled = true);
+  }
+  ```
 
   If you want to output warnings emitted by the library remember to set the log level to `Warning` or lower for `Darkloop` category in your `host.json` file:
 

--- a/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/Startup.cs
+++ b/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -63,7 +64,10 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions.V4
             // decorated with FunctionAuthorizeAttribute you can add the following configuration.
             // If you bind it to configuration, you can modify the setting remotely using
             // Azure App Configuration or other configuration providers without the need to restart app.
-            builder.Services.Configure<FunctionsAuthorizationOptions>(Configuration.GetSection("AuthOptions"));
+            if (builder.IsLocalAuthorizationContext())
+            {
+                builder.Services.Configure<FunctionsAuthorizationOptions>(Configuration.GetSection("AuthOptions"));
+            }
         }
 
         public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)

--- a/src/DarkLoop.Azure.Functions.Authorize/FunctionsHosBuilderExtensions.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/FunctionsHosBuilderExtensions.cs
@@ -1,0 +1,24 @@
+﻿using DarkLoop.Azure.Functions.Authorize.Security;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for <see cref="IFunctionsHostBuilder"/>.
+    /// </summary>
+    public static class FunctionsHostBuilderExtensions
+    {
+        /// <summary>
+        /// Returns a value indicating whether the current environment is local development.
+        /// </summary>
+        /// <param name="builder">The current builder.</param>
+        /// <returns></returns>
+        public static bool IsLocalAuthorizationContext(this IFunctionsHostBuilder builder)
+        {
+            return AuthHelper.IsLocalDevelopment;
+        }
+    }
+}

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/AuthHelper.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/AuthHelper.cs
@@ -18,6 +18,8 @@ namespace DarkLoop.Azure.Functions.Authorize.Security
 
         internal static bool EnableAuth { get; private set; }
 
+        internal static bool IsLocalDevelopment => !EnableAuth;
+
         static AuthHelper()
         {
             var entry = Assembly.GetEntryAssembly();


### PR DESCRIPTION
Adding method that allows to check if running in local dev environment and enable the following scenario:
```c#
if (builder.IsLocalAuthorizationContext())
{
    builder.Services.Configure<FunctionsAuthorizationOptions>(
        options => options.AuthorizationDisabled = true);
}
```