### PR TITLE
Allow for disabling authorization and removing host config when using custom JWT on Bearer

### DIFF
--- a/.build/release.props
+++ b/.build/release.props
@@ -4,7 +4,7 @@
         <Authors>Arturo Martinez</Authors>
 		<Company>DarkLoop</Company>
         <PackageId>DarkLoop.Azure.Functions.Authorize</PackageId>
-        <IsPreview>true</IsPreview>
+        <IsPreview>false</IsPreview>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
         <Version>3.1.3</Version>
         <FileVersion>$(Version).0</FileVersion>

--- a/.build/release.props
+++ b/.build/release.props
@@ -4,9 +4,9 @@
         <Authors>Arturo Martinez</Authors>
 		<Company>DarkLoop</Company>
         <PackageId>DarkLoop.Azure.Functions.Authorize</PackageId>
-        <IsPreview>false</IsPreview>
+        <IsPreview>true</IsPreview>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
-        <Version>3.1.2</Version>
+        <Version>3.1.3</Version>
         <FileVersion>$(Version).0</FileVersion>
         <RepositoryUrl>https://github.com/dark-loop/functions-authorize</RepositoryUrl>
         <License>https://github.com/dark-loop/functions-authorize/blob/master/LICENSE</License>

--- a/.build/release.props
+++ b/.build/release.props
@@ -11,12 +11,12 @@
         <RepositoryUrl>https://github.com/dark-loop/functions-authorize</RepositoryUrl>
         <License>https://github.com/dark-loop/functions-authorize/blob/master/LICENSE</License>
         <RepositoryType>Git</RepositoryType>
-        <PackageTags>AuthorizeAttribute, Authorize, Azure Functions, Azure, Bearer, JWT</PackageTags>
+        <PackageTags>AuthorizeAttribute, Authorize, Azure Functions, Azure, Bearer, JWT, Policy based authorization</PackageTags>
         <PackageIconUrl>https://en.gravatar.com/userimage/22176525/45f25acea686a783e5b2ca172d72db71.png</PackageIconUrl>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>dl-sftwr-sn-key.snk</AssemblyOriginatorKeyFile>
         <IsPackable>true</IsPackable>
-		<Description>Azure Functions V3 authentication extensions to enable authentication and authorization on a per function basis.</Description>
+		<Description>Azure Functions V3 authentication extensions to enable authentication and authorization on a per function basis based on ASPNET Core frameworks.</Description>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Adding change log starting with version 3.1.3
 
   Optionally you can bind it to configuration to rely on providers like User Secrets or Azure App Configuration to disable and re-enable without having to restart your application:
   ```c#
-  builder.Services.Configure<FunctionsAuthorizationOptions>(Configuration.GetSection("FunctionsAuthorization"));
+  builder.Services.Configure<FunctionsAuthorizationOptions>(
+      Configuration.GetSection("FunctionsAuthorization"));
   ```
 
   For function apps targeting .NET 7 or greater, you can also use `AuthorizationBuilder` to set this value:
@@ -116,7 +117,14 @@ Adding change log starting with version 3.1.3
       .DisableAuthorization(Configuration.GetValue<bool>("AuthOptions:DisableAuthorization"));
   ```
 
-  Its always recommended to encapsulate this logic within checks for environments to ensure that if the configuration setting is unintentionally moved to a non-desired environment, it would not affect security of our HTTP triggered functions.
+  Its always recommended to encapsulate this logic within checks for environments to ensure that if the configuration setting is unintentionally moved to a non-desired environment, it would not affect security of our HTTP triggered functions. This change adds a helper method to identify if you are running the function app in the local environment:
+  ```c#
+  if (builder.IsLocalAuthorizationContext())
+  {
+      builder.Services.Configure<FunctionsAuthorizationOptions>(
+          options => options.AuthorizationDisabled = true);
+  }
+  ```
 
   If you want to output warnings emitted by the library remember to set the log level to `Warning` or lower for `Darkloop` category in your `host.json` file:
 

--- a/README.md
+++ b/README.md
@@ -89,3 +89,8 @@ public class Functions
 
 ### Builds
 ![master build status](https://dev.azure.com/darkloop/DarkLoop%20Core%20Library/_apis/build/status/Open%20Source/Functions%20Authorize%20-%20Pack?branchName=master)
+
+## Change log
+Adding change log starting with version 3.1.3
+
+### 3.1.3

--- a/README.md
+++ b/README.md
@@ -94,6 +94,44 @@ public class Functions
 Adding change log starting with version 3.1.3
 
 ### 3.1.3
+- #### Support for disabling `FunctionAuthorize` effect at the application level.
+  Adding support for disabling the effect of `[FunctionAuthorize]` attribute at the application level.  
+  This is useful when wanting to disable authorization for a specific environment, such as local development.
+
+  When configuring services, you can now configure `FunctionsAuthorizationOptions`.
+  ```c#
+  builder.Services.Configure<FunctionsAuthorizationOptions>(options => 
+      options.DisableAuthorization = Configuration.GetValue<bool>("AuthOptions:DisableAuthorization"));
+  ```
+
+  Optionally you can bind it to configuration to rely on providers like User Secrets or Azure App Configuration to disable and re-enable without having to restart your application:
+  ```c#
+  builder.Services.Configure<FunctionsAuthorizationOptions>(Configuration.GetSection("FunctionsAuthorization"));
+  ```
+
+  For function apps targeting .NET 7 or greater, you can also use `AuthorizationBuilder` to set this value:
+  ```c#
+  builder.Services
+      .AddAuthorizationBuilder()
+      .DisableAuthorization(Configuration.GetValue<bool>("AuthOptions:DisableAuthorization"));
+  ```
+
+  Its always recommended to encapsulate this logic within checks for environments to ensure that if the configuration setting is unintentionally moved to a non-desired environment, it would not affect security of our HTTP triggered functions.
+
+  If you want to output warnings emitted by the library remember to set the log level to `Warning` or lower for `Darkloop` category in your `host.json` file:
+
+  ```json
+  {
+    "logging": {
+      "logLevel": {
+        "DarkLoop": "Warning"
+      }
+    }
+  }
+  ```
+  
+  Thanks to [BenjaminWang1031](https://github.com/BenjaminWang1031) for the suggestion to add this functionality.
+
 - #### Remove Functions bult-in JwtBearer configuration by default (Breaking change?)
   Azure Functions recently [added configuration](https://github.com/Azure/azure-functions-host/pull/9678) for issuer and audience validation for the default authentication flows, not the one supported by this package through `FunctionAuthorizeAttribute`, which interferes with token validation when using our own Bearer scheme token configuration.
   In prior versions, this package has functionality to clear Functions built-in configuration, but it was not enabled by default when using `AddJwtBearer(Action<JwtBearerOptions> configure, bool removeBuiltInConfig = false)`. Since the use of this package is commonly used for custom JWT token, the default value of `removeBuiltInConfig` is now `true`.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Adding change log starting with version 3.1.3
       .DisableAuthorization(Configuration.GetValue<bool>("AuthOptions:DisableAuthorization"));
   ```
 
-  Its always recommended to encapsulate this logic within checks for environments to ensure that if the configuration setting is unintentionally moved to a non-desired environment, it would not affect security of our HTTP triggered functions. This change adds a helper method to identify if you are running the function app in the local environment:
+  It's always recommended to encapsulate this logic within checks for environments to ensure that if the configuration setting is unintentionally moved to a non-desired environment, it would not affect security of our HTTP triggered functions. This change adds a helper method to identify if you are running the function app in the local environment:
   ```c#
   if (builder.IsLocalAuthorizationContext())
   {
@@ -140,6 +140,6 @@ Adding change log starting with version 3.1.3
   
   Thanks to [BenjaminWang1031](https://github.com/BenjaminWang1031) for the suggestion to add this functionality.
 
-- #### Remove Functions bult-in JwtBearer configuration by default (Breaking change?)
+- #### Remove Functions bult-in JwtBearer configuration by default
   Azure Functions recently [added configuration](https://github.com/Azure/azure-functions-host/pull/9678) for issuer and audience validation for the default authentication flows, not the one supported by this package through `FunctionAuthorizeAttribute`, which interferes with token validation when using our own Bearer scheme token configuration.
   In prior versions, this package has functionality to clear Functions built-in configuration, but it was not enabled by default when using `AddJwtBearer(Action<JwtBearerOptions> configure, bool removeBuiltInConfig = false)`. Since the use of this package is commonly used for custom JWT token, the default value of `removeBuiltInConfig` is now `true`.

--- a/README.md
+++ b/README.md
@@ -94,3 +94,6 @@ public class Functions
 Adding change log starting with version 3.1.3
 
 ### 3.1.3
+- #### Remove Functions bult-in JwtBearer configuration by default (Breaking change?)
+  Azure Functions recently [added configuration](https://github.com/Azure/azure-functions-host/pull/9678) for issuer and audience validation for the default authentication flows, not the one supported by this package through `FunctionAuthorizeAttribute`, which interferes with token validation when using our own Bearer scheme token configuration.
+  In prior versions, this package has functionality to clear Functions built-in configuration, but it was not enabled by default when using `AddJwtBearer(Action<JwtBearerOptions> configure, bool removeBuiltInConfig = false)`. Since the use of this package is commonly used for custom JWT token, the default value of `removeBuiltInConfig` is now `true`.

--- a/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4.csproj
+++ b/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
 		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
 	</ItemGroup>
 	<ItemGroup>

--- a/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/Startup.cs
+++ b/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/Startup.cs
@@ -1,5 +1,7 @@
 ﻿using DarkLoop.Azure.Functions.Authorize.SampleFunctions.V4;
+using DarkLoop.Azure.Functions.Authorize.Security;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
@@ -56,11 +58,17 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions.V4
                 }, true);
 
             builder.Services.AddFunctionsAuthorization();
+
+            // If you want to disable authorization for all functions
+            // decorated with FunctionAuthorizeAttribute you can add the following configuration.
+            // If you bind it to configuration, you can modify the setting remotely using
+            // Azure App Configuration or other configuration providers without the need to restart app.
+            builder.Services.Configure<FunctionsAuthorizationOptions>(Configuration.GetSection("AuthOptions"));
         }
 
         public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)
         {
-            builder.ConfigurationBuilder.AddUserSecrets<Startup>();
+            builder.ConfigurationBuilder.AddUserSecrets<Startup>(false, reloadOnChange: true);
 
             Configuration = builder.ConfigurationBuilder.Build();
 

--- a/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/Startup.cs
+++ b/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -63,7 +64,10 @@ namespace DarkLoop.Azure.Functions.Authorize.SampleFunctions.V4
             // decorated with FunctionAuthorizeAttribute you can add the following configuration.
             // If you bind it to configuration, you can modify the setting remotely using
             // Azure App Configuration or other configuration providers without the need to restart app.
-            builder.Services.Configure<FunctionsAuthorizationOptions>(Configuration.GetSection("AuthOptions"));
+            if (builder.IsLocalAuthorizationContext())
+            {
+                builder.Services.Configure<FunctionsAuthorizationOptions>(Configuration.GetSection("AuthOptions"));
+            }
         }
 
         public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)

--- a/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/host.json
+++ b/sample/Darkloop.Azure.Functions.Authorize.SampleFunctions.V4/host.json
@@ -1,11 +1,14 @@
 {
     "version": "2.0",
     "logging": {
-        "applicationInsights": {
-            "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
-            }
+      "applicationInsights": {
+        "samplingSettings": {
+          "isEnabled": true,
+          "excludedTypes": "Request"
         }
+      },
+      "logLevel": {
+        "Darkloop": "Information"
+      }
     }
 }

--- a/src/DarkLoop.Azure.Functions.Authorize/DarkLoop.Azure.Functions.Authorize.csproj
+++ b/src/DarkLoop.Azure.Functions.Authorize/DarkLoop.Azure.Functions.Authorize.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.1;net7.0</TargetFrameworks>
         <Version>0.0.1-preview</Version>
         <Company>DarkLoop</Company>
         <Copyright>DarkLoop - All rights reserved</Copyright>
@@ -25,7 +25,7 @@
       <None Include="..\..\.editorconfig" Link=".editorconfig" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.0.3" />
         <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
@@ -36,6 +36,17 @@
             </IncludeAssets>
         </PackageReference>
     </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12">
+      <IncludeAssets>
+        <IsPackable>true</IsPackable>
+      </IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
     <ItemGroup>
         <None Update="local.settings.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/DarkLoop.Azure.Functions.Authorize/Filters/FunctionsAuthorizeFilter.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Filters/FunctionsAuthorizeFilter.cs
@@ -6,8 +6,11 @@ using DarkLoop.Azure.Functions.Authorize.Security;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace DarkLoop.Azure.Functions.Authorize.Filters
 {
@@ -17,6 +20,9 @@ namespace DarkLoop.Azure.Functions.Authorize.Filters
             AuthHelper.EnableAuth ? 
                 new[] { Constants.WebJobsAuthScheme } :
                 new[] { Constants.WebJobsAuthScheme, Constants.ArmTokenAuthScheme };  
+
+        private readonly IOptionsMonitor<FunctionsAuthorizationOptions> _authOptionsMonitor;
+        private readonly ILogger<FunctionsAuthorizeFilter> _logger;
 
         public IEnumerable<IAuthorizeData> AuthorizeData { get; }
 
@@ -29,8 +35,12 @@ namespace DarkLoop.Azure.Functions.Authorize.Filters
         public FunctionsAuthorizeFilter(
             IAuthenticationSchemeProvider schemeProvider,
             IAuthorizationPolicyProvider policyProvider,
-            IEnumerable<IAuthorizeData> authorizeData)
+            IEnumerable<IAuthorizeData> authorizeData,
+            IOptionsMonitor<FunctionsAuthorizationOptions> authorizationOptions,
+            ILogger<FunctionsAuthorizeFilter> logger)
         {
+            this._authOptionsMonitor = authorizationOptions;
+            this._logger = logger;
             this.SchemeProvider = schemeProvider;
             this.PolicyProvider = policyProvider;
             this.AuthorizeData = authorizeData;
@@ -59,6 +69,14 @@ namespace DarkLoop.Azure.Functions.Authorize.Filters
 
         public async Task AuthorizeAsync(FunctionAuthorizationContext context)
         {
+            if (this._authOptionsMonitor.CurrentValue.AuthorizationDisabled)
+            {
+                _logger.LogWarning(
+                    $"Authorization through FunctionAuthorizeAttribute is disabled at the application level. Skipping authorization for {context.HttpContext.Request.GetDisplayUrl()}.");
+
+                return;
+            }
+
             if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (context.HttpContext.Items.ContainsKey(Constants.AuthInvokedKey))
@@ -92,7 +110,7 @@ namespace DarkLoop.Azure.Functions.Authorize.Filters
                 throw new InvalidOperationException("Policy cannot be created.");
             }
 
-            return AuthorizationPolicy.CombineAsync(this.PolicyProvider, this.AuthorizeData);
+            return AuthorizationPolicy.CombineAsync(this.PolicyProvider, this.AuthorizeData)!;
         }
     }
 }

--- a/src/DarkLoop.Azure.Functions.Authorize/Filters/IFunctionsAuthorizationFilterIndex.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Filters/IFunctionsAuthorizationFilterIndex.cs
@@ -7,7 +7,7 @@ namespace DarkLoop.Azure.Functions.Authorize.Filters
 {
     interface IFunctionsAuthorizationFilterIndex
     {
-        IFunctionsAuthorizeFilter GetAuthorizationFilter(string functionName);
+        IFunctionsAuthorizeFilter? GetAuthorizationFilter(string functionName);
 
         void AddAuthorizationFilter(MethodInfo functionMethod, FunctionNameAttribute nameAttribute, IEnumerable<IAuthorizeData> authorizeData);
     }

--- a/src/DarkLoop.Azure.Functions.Authorize/FunctionsHosBuilderExtensions.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/FunctionsHosBuilderExtensions.cs
@@ -1,0 +1,24 @@
+﻿using DarkLoop.Azure.Functions.Authorize.Security;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for <see cref="IFunctionsHostBuilder"/>.
+    /// </summary>
+    public static class FunctionsHostBuilderExtensions
+    {
+        /// <summary>
+        /// Returns a value indicating whether the current environment is local development.
+        /// </summary>
+        /// <param name="builder">The current builder.</param>
+        /// <returns></returns>
+        public static bool IsLocalAuthorizationContext(this IFunctionsHostBuilder builder)
+        {
+            return AuthHelper.IsLocalDevelopment;
+        }
+    }
+}

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/AuthHelper.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/AuthHelper.cs
@@ -18,6 +18,8 @@ namespace DarkLoop.Azure.Functions.Authorize.Security
 
         internal static bool EnableAuth { get; private set; }
 
+        internal static bool IsLocalDevelopment => !EnableAuth;
+
         static AuthHelper()
         {
             var entry = Assembly.GetEntryAssembly();

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/AuthorizationBuilderExtensions.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/AuthorizationBuilderExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DarkLoop.Azure.Functions.Authorize.Security
+{
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// Extension methods for <see cref="AuthorizationBuilder"/>
+    /// </summary>
+    public static class AuthorizationBuilderExtensions
+    {
+        /// <summary>
+        /// Disables authorization for functions decorated with <see cref="FunctionAuthorizeAttribute"/>
+        /// </summary>
+        /// <param name="builder">The current <see cref="AuthorizationBuilder"/> instance.</param>
+        /// <param name="disabled">A value indicating whether authorization is disabled.</param>
+        /// <returns></returns>
+        public static AuthorizationBuilder DisableAuthorization(this AuthorizationBuilder builder, bool disabled)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Services.Configure<FunctionsAuthorizationOptions>(options => options.AuthorizationDisabled = disabled);
+            return builder;
+        }
+    }
+#endif
+}

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/AuthorizationExtensions.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/AuthorizationExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds Functions built-in auhotrization.
+        /// Adds Functions built-in authorization.
         /// </summary>
         /// <param name="services">The service collection to configure.</param>
         public static IServiceCollection AddFunctionsAuthorization(this IServiceCollection services)

--- a/src/DarkLoop.Azure.Functions.Authorize/Security/FunctionsAuthorizationOptions.cs
+++ b/src/DarkLoop.Azure.Functions.Authorize/Security/FunctionsAuthorizationOptions.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DarkLoop.Azure.Functions.Authorize.Security
+{
+    /// <summary>
+    /// Options to manage Authorization functionality for Azure Functions.
+    /// </summary>
+    public class FunctionsAuthorizationOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether authorization is disabled.
+        /// </summary>
+        public bool AuthorizationDisabled {get; set;}
+    }
+}

--- a/test/DarkLoop.Azure.Functions.Authorize.Tests/DarkLoop.Azure.Functions.Authorize.Tests.csproj
+++ b/test/DarkLoop.Azure.Functions.Authorize.Tests/DarkLoop.Azure.Functions.Authorize.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
- #### Support for disabling `FunctionAuthorize` effect at the application level.
  Adding support for disabling the effect of `[FunctionAuthorize]` attribute at the application level.  
  This is useful when wanting to disable authorization for a specific environment, such as local development.
   
  Thanks to [BenjaminWang1031](https://github.com/BenjaminWang1031) for the suggestion to add this functionality.

- #### Remove Functions bult-in JwtBearer configuration by default
  Azure Functions recently [added configuration](https://github.com/Azure/azure-functions-host/pull/9678) for issuer and audience validation for the default authentication flows, not the one supported by this package through `FunctionAuthorizeAttribute`, which interferes with token validation when using our own Bearer scheme token configuration.
  In prior versions, this package has functionality to clear Functions built-in configuration, but it was not enabled by default when using `AddJwtBearer(Action<JwtBearerOptions> configure, bool removeBuiltInConfig = false)`. Since the use of this package is commonly used for custom JWT token, the default value of `removeBuiltInConfig` is now `true`.