### PR TITLE
renaming authorize to authorization.inprocess

### DIFF
--- a/.build/release.props
+++ b/.build/release.props
@@ -8,7 +8,7 @@
     <Product>DarkLoop's Azure Functions Authorization</Product>
     <IsPreview>false</IsPreview>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <FileVersion>$(Version).0</FileVersion>
     <RepositoryUrl>https://github.com/dark-loop/functions-authorize</RepositoryUrl>
     <License>https://github.com/dark-loop/functions-authorize/blob/master/LICENSE</License>

--- a/Functions-Authorize.sln
+++ b/Functions-Authorize.sln
@@ -37,7 +37,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{284270FA-368
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DarkLoop.Azure.Functions.Authorization.Abstractions", "src\abstractions\DarkLoop.Azure.Functions.Authorization.Abstractions.csproj", "{323DA8F9-DC74-491D-9B52-8F58ABAB2B47}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DarkLoop.Azure.Functions.Authorize", "src\in-proc\DarkLoop.Azure.Functions.Authorize.csproj", "{5766D189-64CA-4735-8378-5D5B529F8EB1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DarkLoop.Azure.Functions.Authorization.InProcess", "src\in-proc\DarkLoop.Azure.Functions.Authorization.InProcess.csproj", "{5766D189-64CA-4735-8378-5D5B529F8EB1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DarkLoop.Azure.Functions.Authorization.Isolated", "src\isolated\DarkLoop.Azure.Functions.Authorization.Isolated.csproj", "{05468E2C-BFCF-49A4-A083-8BEE26767FA5}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This projects is open source and may be redistributed under the terms of the [Ap
 ## Change log
 Adding change log starting with version 3.1.3
 
+### 4.0.1
+Deprecating `DarkLoop.Azure.Functions.Authorize` package in favor of `DarkLoop.Azure.Functions.Authorization.InProcess` package.<br/>
+The functionality remains the same, it's just a way to keep package naming in sync.
+
 ### 4.0.0
 Starting from 4.0.0, support for Azure Functions V4 Isolated mode with ASPNET Core integration is added.
 The package is now split into two separate packages, one for each mode. 

--- a/sample/SampleInProcFunctions.V4/SampleInProcFunctions.V4.csproj
+++ b/sample/SampleInProcFunctions.V4/SampleInProcFunctions.V4.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.2" />
 	</ItemGroup>
 	<ItemGroup>
-	  <ProjectReference Include="..\..\src\in-proc\DarkLoop.Azure.Functions.Authorize.csproj" />
+	  <ProjectReference Include="..\..\src\in-proc\DarkLoop.Azure.Functions.Authorization.InProcess.csproj" />
 	  <ProjectReference Include="..\..\test\Common.Tests\Common.Tests.csproj" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/abstractions/DarkLoop.Azure.Functions.Authorization.Abstractions.csproj
+++ b/src/abstractions/DarkLoop.Azure.Functions.Authorization.Abstractions.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="DarkLoop.Azure.Functions.Authorize" Key="$(PublicKey)" />
+    <InternalsVisibleTo Include="DarkLoop.Azure.Functions.Authorization.InProcess" Key="$(PublicKey)" />
     <InternalsVisibleTo Include="DarkLoop.Azure.Functions.Authorization.Isolated" Key="$(PublicKey)" />
     <InternalsVisibleTo Include="Abstractions.Tests" Key="$(PublicKey)" />
     <InternalsVisibleTo Include="Isolated.Tests" Key="$(PublicKey)" />

--- a/src/in-proc/DarkLoop.Azure.Functions.Authorization.InProcess.csproj
+++ b/src/in-proc/DarkLoop.Azure.Functions.Authorization.InProcess.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <RootNamespace>DarkLoop.Azure.Functions.Authorization</RootNamespace>
-    <AssemblyName>DarkLoop.Azure.Functions.Authorize</AssemblyName>
+    <AssemblyName>DarkLoop.Azure.Functions.Authorization.InProcess</AssemblyName>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Version>0.0.1-preview</Version>
     <UserSecretsId>3472ff41-3859-4101-a2da-6c37d751fd31</UserSecretsId>

--- a/test/InProc.Tests/InProc.Tests.csproj
+++ b/test/InProc.Tests/InProc.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\in-proc\DarkLoop.Azure.Functions.Authorize.csproj" />
+    <ProjectReference Include="..\..\src\in-proc\DarkLoop.Azure.Functions.Authorization.InProcess.csproj" />
     <ProjectReference Include="..\Common.Tests\Common.Tests.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Renaming public name of package. this will deprecate `DarkLoop.Azure.Functions.Authorize