### PR TITLE
Support storing AuthenticateResult in HttpContext/FunctionContext

### DIFF
--- a/.build/release.props
+++ b/.build/release.props
@@ -6,7 +6,7 @@
     <Company>DarkLoop</Company>
     <Copyright>DarkLoop - All rights reserved</Copyright>
     <Product>DarkLoop's Azure Functions Authorization</Product>
-    <IsPreview>false</IsPreview>
+    <IsPreview>true</IsPreview>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <Version>4.1.1</Version>
     <FileVersion>$(Version).0</FileVersion>

--- a/.build/release.props
+++ b/.build/release.props
@@ -8,7 +8,7 @@
     <Product>DarkLoop's Azure Functions Authorization</Product>
     <IsPreview>false</IsPreview>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <Version>4.1.0</Version>
+    <Version>4.1.1</Version>
     <FileVersion>$(Version).0</FileVersion>
     <RepositoryUrl>https://github.com/dark-loop/functions-authorize</RepositoryUrl>
     <License>https://github.com/dark-loop/functions-authorize/blob/master/LICENSE</License>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,9 @@
 # Change log
 Change log stars with version 3.1.3
 
+## 4.1.1
+After authenticate but before authorize IAuthenticateResultFeature and IHttpAuthenticationFeature are now both set in HttpContext.Features and (for isolated Azure Functions) FunctionContext.Features.
+
 ## 4.1.0
 - ### [Breaking] Removing support for `Bearer` scheme and adding `FunctionsBearer`
   Recent security updates in the Azure Functions runtime are clashing with the use of the default, well known `Bearer` scheme.<br/>

--- a/src/abstractions/FunctionAuthorizationFeature.cs
+++ b/src/abstractions/FunctionAuthorizationFeature.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="FunctionAuthorizationFeature.cs" company="DarkLoop" author="Arturo Martinez">
+//  Copyright (c) DarkLoop. All rights reserved.
+// </copyright>
+
+using DarkLoop.Azure.Functions.Authorization.Internal;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http.Features.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DarkLoop.Azure.Functions.Authorization
+{
+    internal sealed class FunctionAuthorizationFeature : IAuthenticateResultFeature, IHttpAuthenticationFeature
+    {
+        private ClaimsPrincipal? _principal;
+        private AuthenticateResult? _authenticateResult;
+
+        public FunctionAuthorizationFeature(AuthenticateResult result)
+        {
+            Check.NotNull(result, nameof(result));
+
+            AuthenticateResult = result;
+        }
+
+
+        public AuthenticateResult? AuthenticateResult 
+        { 
+            get => _authenticateResult;
+            set
+            {
+                _authenticateResult = value;
+                _principal = value?.Principal;
+            }
+        }
+
+        public ClaimsPrincipal? User 
+        { 
+            get => _principal; 
+            set
+            {
+                _authenticateResult = null;
+                _principal = value;
+            }
+        }
+    }
+}

--- a/src/abstractions/FunctionAuthorizationFeature.cs
+++ b/src/abstractions/FunctionAuthorizationFeature.cs
@@ -5,20 +5,21 @@
 using DarkLoop.Azure.Functions.Authorization.Internal;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http.Features.Authentication;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DarkLoop.Azure.Functions.Authorization
 {
+    // This was designed with maximum compatibility with ASP.NET core. It keeps
+    // two separate features in sync with each other automatically.
     internal sealed class FunctionAuthorizationFeature : IAuthenticateResultFeature, IHttpAuthenticationFeature
     {
         private ClaimsPrincipal? _principal;
         private AuthenticateResult? _authenticateResult;
 
+        /// <summary>
+        /// Construct an instance of the feature with the given AuthenticateResult
+        /// </summary>
+        /// <param name="result"></param>
         public FunctionAuthorizationFeature(AuthenticateResult result)
         {
             Check.NotNull(result, nameof(result));
@@ -26,7 +27,7 @@ namespace DarkLoop.Azure.Functions.Authorization
             AuthenticateResult = result;
         }
 
-
+        /// <inheritdoc/>
         public AuthenticateResult? AuthenticateResult 
         { 
             get => _authenticateResult;
@@ -37,6 +38,7 @@ namespace DarkLoop.Azure.Functions.Authorization
             }
         }
 
+        /// <inheritdoc/>
         public ClaimsPrincipal? User 
         { 
             get => _principal; 

--- a/src/abstractions/Internal/FunctionsFeatureCollectionExtension.cs
+++ b/src/abstractions/Internal/FunctionsFeatureCollectionExtension.cs
@@ -5,17 +5,20 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DarkLoop.Azure.Functions.Authorization.Internal
 {
+    // This functionality is used internally to emulate Asp.net's treatment of AuthenticateResult
     internal static class FunctionsFeatureCollectionExtension
     {
-        public static void SetAuthenticationFeatures(this IFeatureCollection features, AuthenticateResult result)
+        /// <summary>
+        /// Store the given AuthenticateResult in the IFeatureCollection accessible via
+        /// IAuthenticateResultFeature and IHttpAuthenticationFeature
+        /// </summary>
+        /// <param name="features">The feature collection to add to</param>
+        /// <param name="result">The authentication to expose in the feature collection</param>
+        /// <returns>The object associated with the features</returns>
+        public static FunctionAuthorizationFeature SetAuthenticationFeatures(this IFeatureCollection features, AuthenticateResult result)
         {
             // A single object is used to handle both of these features so that they stay in sync.
             // This is in line with what asp core normally does.
@@ -23,6 +26,8 @@ namespace DarkLoop.Azure.Functions.Authorization.Internal
 
             features.Set<IAuthenticateResultFeature>(feature);
             features.Set<IHttpAuthenticationFeature>(feature);
+
+            return feature;
         }
     }
 }

--- a/src/abstractions/Internal/FunctionsFeatureCollectionExtension.cs
+++ b/src/abstractions/Internal/FunctionsFeatureCollectionExtension.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="FunctionsFeatureCollectionExtension.cs" company="DarkLoop" author="Arturo Martinez">
+//  Copyright (c) DarkLoop. All rights reserved.
+// </copyright>
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Features.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DarkLoop.Azure.Functions.Authorization.Internal
+{
+    internal static class FunctionsFeatureCollectionExtension
+    {
+        public static void SetAuthenticationFeatures(this IFeatureCollection features, AuthenticateResult result)
+        {
+            // A single object is used to handle both of these features so that they stay in sync.
+            // This is in line with what asp core normally does.
+            var feature = new FunctionAuthorizationFeature(result);
+
+            features.Set<IAuthenticateResultFeature>(feature);
+            features.Set<IHttpAuthenticationFeature>(feature);
+        }
+    }
+}

--- a/src/in-proc/FunctionsAuthorizationExecutor.cs
+++ b/src/in-proc/FunctionsAuthorizationExecutor.cs
@@ -79,6 +79,8 @@ namespace DarkLoop.Azure.Functions.Authorization
 
             var authenticateResult = await _policyEvaluator.AuthenticateAsync(filter.Policy, httpContext);
 
+            httpContext.Features.SetAuthenticationFeatures(authenticateResult);
+
             // still authenticating in case token is sent to set context user but skipping authorization
             if (filter.AllowAnonymous)
             {

--- a/src/isolated/FunctionsAuthorizationMiddleware.cs
+++ b/src/isolated/FunctionsAuthorizationMiddleware.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading.Tasks;
 using DarkLoop.Azure.Functions.Authorization.Internal;
 using DarkLoop.Azure.Functions.Authorization.Properties;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -82,6 +83,8 @@ namespace DarkLoop.Azure.Functions.Authorization
             }
 
             var authenticateResult = await _policyEvaluator.AuthenticateAsync(filter.Policy, httpContext);
+
+            httpContext.Features.SetAuthenticationFeatures(authenticateResult);
 
             if (filter.AllowAnonymous)
             {

--- a/src/isolated/FunctionsAuthorizationMiddleware.cs
+++ b/src/isolated/FunctionsAuthorizationMiddleware.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
 using Microsoft.Extensions.Logging;
@@ -84,7 +85,11 @@ namespace DarkLoop.Azure.Functions.Authorization
 
             var authenticateResult = await _policyEvaluator.AuthenticateAsync(filter.Policy, httpContext);
 
-            httpContext.Features.SetAuthenticationFeatures(authenticateResult);
+            var authenticateFeature = httpContext.Features.SetAuthenticationFeatures(authenticateResult);
+
+            // We also make the features available in the FunctionContext 
+            context.Features.Set<IAuthenticateResultFeature>(authenticateFeature);
+            context.Features.Set<IHttpAuthenticationFeature>(authenticateFeature);
 
             if (filter.AllowAnonymous)
             {

--- a/test/Common.Tests/HttpUtils.cs
+++ b/test/Common.Tests/HttpUtils.cs
@@ -25,11 +25,12 @@ namespace Common.Tests
             var streamReader = PipeReader.Create(requestStream);
             var requestHeaders = new HeaderDictionary();
             var streamWriter = PipeWriter.Create(responseStream);
+            var features = new FeatureCollection();
 
             httpContextMock.SetupGet(x => x.RequestServices).Returns(services);
             httpContextMock.SetupGet(x => x.Request).Returns(requestMock.Object);
             httpContextMock.SetupGet(x => x.Response).Returns(responseMock.Object);
-            httpContextMock.SetupGet(x => x.Features).Returns(Mock.Of<IFeatureCollection>());
+            httpContextMock.SetupGet(x => x.Features).Returns(features);
             httpContextMock.SetupGet(x => x.Items).Returns(new Dictionary<object, object?>());
             requestMock.SetupGet(x => x.RouteValues).Returns(new RouteValueDictionary());
             requestMock.SetupGet(x => x.Body).Returns(requestStream);
@@ -43,5 +44,6 @@ namespace Common.Tests
 
             return httpContextMock.Object;
         }
+
     }
 }

--- a/test/InProc.Tests/FunctionsAuthorizationExecutorTests.cs
+++ b/test/InProc.Tests/FunctionsAuthorizationExecutorTests.cs
@@ -238,7 +238,7 @@ namespace InProc.Tests
             policyEvaluatorMock.Verify(evaluator => evaluator.AuthorizeAsync(It.IsAny<AuthorizationPolicy>(), It.IsAny<AuthenticateResult>(), It.IsAny<HttpContext>(), It.IsAny<object>()), Times.Once);
         }
 
-        [TestMethod("AuthorizationExecutor: should throw when failed authentication and does not allow anonymous with Forbid")]
+        [TestMethod("AuthorizationExecutor: should set http features on authenticate success or failure")]
         public async Task AuthorizationExecutorShouldSetHttpFeaturesOnSuccessOrFailure()
         {
             // Arrange

--- a/test/InProc.Tests/FunctionsAuthorizationExecutorTests.cs
+++ b/test/InProc.Tests/FunctionsAuthorizationExecutorTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -235,6 +236,46 @@ namespace InProc.Tests
             await action.Should().ThrowAsync<FunctionAuthorizationException>();
             policyEvaluatorMock.Verify(evaluator => evaluator.AuthenticateAsync(It.IsAny<AuthorizationPolicy>(), It.IsAny<HttpContext>()), Times.Once);
             policyEvaluatorMock.Verify(evaluator => evaluator.AuthorizeAsync(It.IsAny<AuthorizationPolicy>(), It.IsAny<AuthenticateResult>(), It.IsAny<HttpContext>(), It.IsAny<object>()), Times.Once);
+        }
+
+        [TestMethod("AuthorizationExecutor: should throw when failed authentication and does not allow anonymous with Forbid")]
+        public async Task AuthorizationExecutorShouldSetHttpFeaturesOnSuccessOrFailure()
+        {
+            // Arrange
+            var options = _services!.GetRequiredService<IOptionsMonitor<FunctionsAuthorizationOptions>>();
+            options.CurrentValue.AuthorizationDisabled = false;
+
+            var authorizationProviderMock = new Mock<IFunctionsAuthorizationProvider>();
+            authorizationProviderMock
+                .Setup(provider => provider.GetAuthorizationAsync(It.IsAny<string>(), It.IsAny<IAuthorizationPolicyProvider>()))
+                .ReturnsAsync(new FunctionAuthorizationFilter(new AuthorizationPolicyBuilder().RequireAssertion(_ => false).Build(), false));
+
+            var policyEvaluatorMock = new Mock<IPolicyEvaluator>();
+            policyEvaluatorMock
+                .Setup(evaluator => evaluator.AuthenticateAsync(It.IsAny<AuthorizationPolicy>(), It.IsAny<HttpContext>()))
+                .ReturnsAsync(AuthenticateResult.Success(new AuthenticationTicket(new System.Security.Claims.ClaimsPrincipal(), "")));
+            policyEvaluatorMock
+                .Setup(evaluator => evaluator.AuthorizeAsync(It.IsAny<AuthorizationPolicy>(), It.IsAny<AuthenticateResult>(), It.IsAny<HttpContext>(), It.IsAny<object>()))
+                .ReturnsAsync(PolicyAuthorizationResult.Success());
+
+            var executor = new FunctionsAuthorizationExecutor(
+                authorizationProviderMock.Object,
+                _services!.GetRequiredService<IFunctionsAuthorizationResultHandler>(),
+                _services!.GetRequiredService<IAuthorizationPolicyProvider>(),
+                policyEvaluatorMock.Object,
+                _services!.GetRequiredService<IOptionsMonitor<FunctionsAuthorizationOptions>>(),
+                _services!.GetRequiredService<ILogger<FunctionsAuthorizationExecutor>>());
+
+            var functionId = Guid.NewGuid();
+            var httpContext = HttpUtils.SetupHttpContext(_services!);
+            var context = SetupExecutingContext(functionId, "TestFunction", httpContext.Request);
+
+            // Act
+            await executor.ExecuteAuthorizationAsync(context, httpContext);
+
+            // Assert
+            Assert.IsNotNull(httpContext.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult);
+            Assert.IsNotNull(httpContext.Features.Get<IHttpAuthenticationFeature>()?.User);
         }
 
         private static FunctionExecutingContext SetupExecutingContext(Guid functionId, string functionName, HttpRequest request)

--- a/test/Isolated.Tests/Fakes/FakeInvocationFeatures.cs
+++ b/test/Isolated.Tests/Fakes/FakeInvocationFeatures.cs
@@ -1,0 +1,36 @@
+﻿// <copyright file="FakeInvocationFeatures.cs" company="DarkLoop" author="Arturo Martinez">
+//  Copyright (c) DarkLoop. All rights reserved.
+// </copyright>
+
+using Microsoft.Azure.Functions.Worker;
+using System.Collections;
+
+namespace Isolated.Tests.Fakes
+{
+    internal sealed class FakeInvocationFeatures : IInvocationFeatures
+    {
+        private Dictionary<Type, object> _underlyingSet = new Dictionary<Type, object>();
+
+        public T? Get<T>()
+        {
+            _underlyingSet.TryGetValue(typeof(T), out var feature);
+
+            return (T?)feature;
+        }
+
+        public IEnumerator<KeyValuePair<Type, object>> GetEnumerator()
+        {
+            return _underlyingSet.GetEnumerator();
+        }
+
+        public void Set<T>(T instance)
+        {
+            _underlyingSet.Add(typeof(T), instance);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _underlyingSet.GetEnumerator();
+        }
+    }
+}

--- a/test/Isolated.Tests/FunctionsAuthorizationMiddlewareTests.cs
+++ b/test/Isolated.Tests/FunctionsAuthorizationMiddlewareTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -235,6 +236,47 @@ namespace Isolated.Tests
             Assert.AreEqual(0, value);
             policyEvaluatorMock.Verify(evaluator => evaluator.AuthenticateAsync(It.IsAny<AuthorizationPolicy>(), It.IsAny<HttpContext>()), Times.Once);
             policyEvaluatorMock.Verify(evaluator => evaluator.AuthorizeAsync(It.IsAny<AuthorizationPolicy>(), It.IsAny<AuthenticateResult>(), It.IsAny<HttpContext>(), It.IsAny<object>()), Times.Once);
+        }
+
+        [TestMethod("AuthorizationMiddleware: on success should set appropriate HttpContext features")]
+        public async Task AuthorizationMiddlewareOnSuccessShouldSetAppropriateHttpContextFeatures()
+        {
+            // Arrange
+            var authorizationProviderMock = new Mock<IFunctionsAuthorizationProvider>();
+            authorizationProviderMock
+                .Setup(provider => provider.GetAuthorizationAsync(It.IsAny<string>(), It.IsAny<IAuthorizationPolicyProvider>()))
+                .ReturnsAsync(new FunctionAuthorizationFilter(new AuthorizationPolicyBuilder().RequireAssertion(_ => false).Build(), false));
+
+            var policyEvaluatorMock = new Mock<IPolicyEvaluator>();
+            policyEvaluatorMock
+                .Setup(evaluator => evaluator.AuthenticateAsync(It.IsAny<AuthorizationPolicy>(), It.IsAny<HttpContext>()))
+                .ReturnsAsync(AuthenticateResult.Success(new AuthenticationTicket(new System.Security.Claims.ClaimsPrincipal(), "fakeauth")));
+            policyEvaluatorMock
+                .Setup(evaluator => evaluator.AuthorizeAsync(It.IsAny<AuthorizationPolicy>(), It.IsAny<AuthenticateResult>(), It.IsAny<HttpContext>(), It.IsAny<object>()))
+                .ReturnsAsync(PolicyAuthorizationResult.Success());
+
+            var middleware = new FunctionsAuthorizationMiddleware(
+                authorizationProviderMock.Object,
+                _services!.GetRequiredService<IFunctionsAuthorizationResultHandler>(),
+                _services!.GetRequiredService<IAuthorizationPolicyProvider>(),
+                policyEvaluatorMock.Object,
+                _services!.GetRequiredService<IOptionsMonitor<FunctionsAuthorizationOptions>>(),
+                _services!.GetRequiredService<ILogger<FunctionsAuthorizationMiddleware>>());
+
+            var functionId = "098039841";
+            var entryPoint = $"{typeof(FakeFunctionClass).FullName}.TestFunction";
+            var httpContext = HttpUtils.SetupHttpContext(_services!);
+            var context = SetupFunctionContext(functionId, "TestFunction", entryPoint, "httpTrigger", "request", httpContext);
+
+            // Act
+            await middleware.Invoke(context, async fc =>
+            {
+                await Task.CompletedTask;
+            });
+
+            // Assert
+            Assert.IsNotNull(httpContext.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult);
+            Assert.IsNotNull(httpContext.Features.Get<IHttpAuthenticationFeature>()?.User);
         }
 
         private FunctionContext SetupFunctionContext(

--- a/test/Isolated.Tests/FunctionsAuthorizationMiddlewareTests.cs
+++ b/test/Isolated.Tests/FunctionsAuthorizationMiddlewareTests.cs
@@ -277,6 +277,9 @@ namespace Isolated.Tests
             // Assert
             Assert.IsNotNull(httpContext.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult);
             Assert.IsNotNull(httpContext.Features.Get<IHttpAuthenticationFeature>()?.User);
+
+            Assert.IsNotNull(context.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult);
+            Assert.IsNotNull(context.Features.Get<IHttpAuthenticationFeature>()?.User);
         }
 
         private FunctionContext SetupFunctionContext(
@@ -296,10 +299,11 @@ namespace Isolated.Tests
             }
 
             var context = new Mock<FunctionContext>();
+            var features = new FakeInvocationFeatures();
             context.Setup(context => context.FunctionId).Returns(functionId);
             context.Setup(context => context.FunctionDefinition.Name).Returns(functionName);
             context.Setup(context => context.FunctionDefinition.EntryPoint).Returns(entryPoint);
-            context.Setup(context => context.Features).Returns(Mock.Of<IInvocationFeatures>());
+            context.Setup(context => context.Features).Returns(features);
             context.Setup(context => context.Items).Returns(items);
             context
                 .Setup(contextMock => contextMock.FunctionDefinition.InputBindings)


### PR DESCRIPTION
During authentication not *all* available information is stored in the user identity/the service principal. Normally ASP.NET stores the full authentication result (AuthenticateResult) in a feature via HttpContext.Features. This PR adds support for storing the authenticate result in the HttpContext. This should promote maximum compatibility with other authentication/authorization middleware designed to use these features.

The AuthenticateResult is also stored in the FunctionContext for ease of use.

Tests were added and I believe I emulated the style _okish_. Please feel free to point out anything I missed!