### PR TITLE
adding explicit target frameworks to mitigate issues between aspnetcore and model identity

### DIFF
--- a/src/abstractions/DarkLoop.Azure.Functions.Authorization.Abstractions.csproj
+++ b/src/abstractions/DarkLoop.Azure.Functions.Authorization.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>DarkLoop.Azure.Functions.Authorization.Abstractions</AssemblyName>
     <RootNamespace>DarkLoop.Azure.Functions.Authorization</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Version>0.0.1-preview</Version>
     <Description>DarkLoop's Azure Functions authorization extension shared core functionality for InProc and Isolated modules.</Description>
     <Nullable>enable</Nullable>
@@ -21,16 +21,27 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Metadata" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Metadata" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Metadata" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Metadata" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/in-proc/DarkLoop.Azure.Functions.Authorization.InProcess.csproj
+++ b/src/in-proc/DarkLoop.Azure.Functions.Authorization.InProcess.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DarkLoop.Azure.Functions.Authorization</RootNamespace>
     <AssemblyName>DarkLoop.Azure.Functions.Authorization.InProcess</AssemblyName>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Version>0.0.1-preview</Version>
     <UserSecretsId>3472ff41-3859-4101-a2da-6c37d751fd31</UserSecretsId>
     <Description>Azure Functions V3 and V4 (InProc) extension to enable authentication and authorization on a per function basis based on ASPNET Core frameworks.</Description>

--- a/src/in-proc/DarkLoop.Azure.Functions.Authorization.InProcess.csproj
+++ b/src/in-proc/DarkLoop.Azure.Functions.Authorization.InProcess.csproj
@@ -33,16 +33,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\abstractions\DarkLoop.Azure.Functions.Authorization.Abstractions.csproj" />
   </ItemGroup>

--- a/src/isolated/DarkLoop.Azure.Functions.Authorization.Isolated.csproj
+++ b/src/isolated/DarkLoop.Azure.Functions.Authorization.Isolated.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>DarkLoop.Azure.Functions.Authorization.Isolated</AssemblyName>
     <RootNamespace>DarkLoop.Azure.Functions.Authorization</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Version>0.0.1-preview</Version>
     <Description>Azure Functions V4 in Isolated mode extension to enable authentication and authorization on a per function basis based on ASPNET Core frameworks.</Description>
     <Nullable>enable</Nullable>

--- a/test/Abstractions.Tests/Abstractions.Tests.csproj
+++ b/test/Abstractions.Tests/Abstractions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/test/InProc.Tests/InProc.Tests.csproj
+++ b/test/InProc.Tests/InProc.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Isolated.Tests/Isolated.Tests.csproj
+++ b/test/Isolated.Tests/Isolated.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This change creates explicit versioning targeting specific versions of .NET (6+) so that referencing the assembly for a specific version forces the reference to the correct `Microsoft.ModelIdentity` package