### PR TITLE
ensuring monitor to let all other threads go

### DIFF
--- a/src/isolated/Metadata/FunctionsAuthorizationMetadataMiddleware.cs
+++ b/src/isolated/Metadata/FunctionsAuthorizationMetadataMiddleware.cs
@@ -57,7 +57,7 @@ namespace DarkLoop.Azure.Functions.Authorization.Metadata
             // is thread-safe on a per function basis.
             // Ensuring key is interned before entering monitor since key is compared as object
             var monitorKey = string.Intern($"famm:{context.FunctionId}");
-            await KeyedMonitor.EnterAsync(monitorKey);
+            await KeyedMonitor.EnterAsync(monitorKey, unblockOnFirstExit: true);
 
             try
             {


### PR DESCRIPTION
after the first metadata generation happens for an individual function no more blocking should happen and it's safe for all awaiting threads to be released.