### PR TITLE
removing arm token invocation

### DIFF
--- a/.build/release.props
+++ b/.build/release.props
@@ -8,7 +8,7 @@
     <Product>DarkLoop's Azure Functions Authorization</Product>
     <IsPreview>true</IsPreview>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <Version>4.1.4</Version>
+    <Version>4.2.0</Version>
     <FileVersion>$(Version).0</FileVersion>
     <RepositoryUrl>https://github.com/dark-loop/functions-authorize</RepositoryUrl>
     <License>https://github.com/dark-loop/functions-authorize/blob/master/LICENSE</License>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,14 @@
 # Change log
 Change log stars with version 3.1.3
 
+## 4.2.0
+- Removing support for STS .NET versions (7.0), as these versions are not supported by Azure Functions runtime.
+- Removing ARM authentication support to align with Azure Functions runtime changes.
+- Aligning IdentityModel packages versions with versions specified in the *Script.WebHost** project.
+
+## 4.1.3
+- Adding support for specifying a scheme in `AddJwtFunctionsBearer` method as an overload. It throws exception if 'Bearer' is used as a scheme name.
+
 ## 4.1.2
 - **[Bug Fix]** The main change in this version is ensuring metadata collection middleware is thread safe when no metadata has been built for a specific function. Thanks @dstenroejl for reporting [issue](https://github.com/dark-loop/functions-authorize/issues/62).
 - Using `FunctionsBearer` scheme in sample application to align with implementation.

--- a/sample/SampleInProcFunctions.V4/SampleInProcFunctions.V4.csproj
+++ b/sample/SampleInProcFunctions.V4/SampleInProcFunctions.V4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<AzureFunctionsVersion>v4</AzureFunctionsVersion>
 		<UserSecretsId>51dc0b9d-8e74-45ec-aebc-1d3d6934faf5</UserSecretsId>
     <IsPackable>false</IsPackable>

--- a/src/abstractions/DarkLoop.Azure.Functions.Authorization.Abstractions.csproj
+++ b/src/abstractions/DarkLoop.Azure.Functions.Authorization.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>DarkLoop.Azure.Functions.Authorization.Abstractions</AssemblyName>
     <RootNamespace>DarkLoop.Azure.Functions.Authorization</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Version>0.0.1-preview</Version>
     <Description>DarkLoop's Azure Functions authorization extension shared core functionality for InProc and Isolated modules.</Description>
     <Nullable>enable</Nullable>
@@ -25,23 +25,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.AspNetCore.Metadata" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.29" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Metadata" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Metadata" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/in-proc/DarkLoop.Azure.Functions.Authorization.InProcess.csproj
+++ b/src/in-proc/DarkLoop.Azure.Functions.Authorization.InProcess.csproj
@@ -3,11 +3,13 @@
   <PropertyGroup>
     <RootNamespace>DarkLoop.Azure.Functions.Authorization</RootNamespace>
     <AssemblyName>DarkLoop.Azure.Functions.Authorization.InProcess</AssemblyName>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Version>0.0.1-preview</Version>
     <UserSecretsId>3472ff41-3859-4101-a2da-6c37d751fd31</UserSecretsId>
     <Description>Azure Functions V3 and V4 (InProc) extension to enable authentication and authorization on a per function basis based on ASPNET Core frameworks.</Description>
     <Nullable>enable</Nullable>
+    <IdentityDependencyVersion Condition="'$(TargetFramework)' == 'net6.0'">6.35.0</IdentityDependencyVersion>
+    <IdentityDependencyVersion Condition="'$(TargetFramework)' == 'net8.0'">7.1.2</IdentityDependencyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -25,10 +27,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityDependencyVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="[3.0.39,)" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="[4.30.0,)">
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="[3.0.41,)" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="[4.834.1,)" Condition="'$(TargetFramework)' == 'net6.0'">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="[4.1036.1,)" Condition="'$(TargetFramework)' == 'net8.0'">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/in-proc/FunctionAuthorizationException.cs
+++ b/src/in-proc/FunctionAuthorizationException.cs
@@ -21,9 +21,6 @@ namespace DarkLoop.Azure.Functions.Authorization
             _statusCode = status;
         }
 
-        /// <inheritdoc/>
-        public FunctionAuthorizationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-
         /// <summary>
         /// Gets the status code that was returned to caller.
         /// </summary>

--- a/src/in-proc/Security/FunctionsAuthenticationServiceCollectionExtensions.cs
+++ b/src/in-proc/Security/FunctionsAuthenticationServiceCollectionExtensions.cs
@@ -53,7 +53,6 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             authBuilder
-                .AddArmToken()
                 .AddScriptAuthLevel()
                 .AddScriptJwtBearer();
 

--- a/src/isolated/DarkLoop.Azure.Functions.Authorization.Isolated.csproj
+++ b/src/isolated/DarkLoop.Azure.Functions.Authorization.Isolated.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>DarkLoop.Azure.Functions.Authorization.Isolated</AssemblyName>
     <RootNamespace>DarkLoop.Azure.Functions.Authorization</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Version>0.0.1-preview</Version>
     <Description>Azure Functions V4 in Isolated mode extension to enable authentication and authorization on a per function basis based on ASPNET Core frameworks.</Description>
     <Nullable>enable</Nullable>
@@ -23,6 +23,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.35.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.1.0" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Abstractions.Tests/Abstractions.Tests.csproj
+++ b/test/Abstractions.Tests/Abstractions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/test/InProc.Tests/InProc.Tests.csproj
+++ b/test/InProc.Tests/InProc.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -16,7 +16,7 @@
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.30.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.WebHost" Version="4.834.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Isolated.Tests/Isolated.Tests.csproj
+++ b/test/Isolated.Tests/Isolated.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Removing `AddArmToken` extension invocation when ensuring native functions host security is setup prior to adding application authentication and align with recent runtime changes as discussed in today's comments for #58.